### PR TITLE
Silence Mongo deprecation warnings

### DIFF
--- a/config.js
+++ b/config.js
@@ -6,9 +6,13 @@ module.exports = {
   PORT: process.env.PORT || 8080,
   CLIENT_ORIGIN: process.env.CLIENT_ORIGIN || 'http://localhost:3000',
   DATABASE_URL:
-    process.env.DATABASE_URL || 'mongodb://localhost/hiphip-backend',
+    process.env.DATABASE_URL || 'mongodb://localhost:27017/hiphip-backend',
   TEST_DATABASE_URL:
-    process.env.TEST_DATABASE_URL || 'mongodb://localhost/hiphip-backend-test',
+    process.env.TEST_DATABASE_URL ||
+    'mongodb://localhost:27017/hiphip-backend-test',
+  MONGO_OPTIONS: {
+    useNewUrlParser: true,
+  },
   JWT_SECRET: process.env.JWT_SECRET,
   JWT_EXPIRY: process.env.JWT_EXPIRY || '7d',
   // DATABASE_URL:

--- a/db/db-mongoose.js
+++ b/db/db-mongoose.js
@@ -3,15 +3,20 @@
 const mongoose = require('mongoose');
 mongoose.Promise = global.Promise;
 
-const { DATABASE_URL } = require('../config');
+const { DATABASE_URL, MONGO_OPTIONS } = require('../config');
 
-function dbConnect(url = DATABASE_URL) {
-  return mongoose.connect(url).catch(err => {
-    /* eslint-disable no-console */
-    console.error('Mongoose failed to connect');
-    console.error(err);
-    /* eslint-enable no-console */
-  });
+function dbConnect(url = DATABASE_URL, connectionOptions = MONGO_OPTIONS) {
+  return mongoose
+    .connect(
+      url,
+      connectionOptions
+    )
+    .catch(err => {
+      /* eslint-disable no-console */
+      console.error('Mongoose failed to connect');
+      console.error(err);
+      /* eslint-enable no-console */
+    });
 }
 
 function dbDisconnect() {

--- a/routes/users.js
+++ b/routes/users.js
@@ -77,7 +77,7 @@ router.post('/', jsonParser, (req, res, next) => {
   let { username, password } = req.body;
 
   return User.find({ username })
-    .count()
+    .countDocuments()
     .then(count => {
       if (count > 0) {
         // There is an existing user with the same username


### PR DESCRIPTION
Unfortunately, there is a bug with the newUrlParser at the moment, and it does
not correctly set the default database port. As a result, the DATABASE_URLs
have been updated to include the default port.

Additionally, Model.count() is now deprecated in favor of countDocuments, so
this was updated in the users router.