### PR TITLE
Prevent accidentally unchecking on patch request

### DIFF
--- a/routes/items.js
+++ b/routes/items.js
@@ -151,7 +151,7 @@ router
           item.name = name;
         }
 
-        if (isChecked !== item.isChecked) {
+        if (isChecked !== undefined && isChecked !== item.isChecked) {
           item.isChecked = isChecked;
         }
 


### PR DESCRIPTION
We weren't checking whether the request body included a isChecked property.